### PR TITLE
Patch/metadata 2 (#20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,52 +3,59 @@ name: Continuous Integration
 on:
   pull_request:
     branches: [main, dev]
-    
+
 jobs:
 
   static-analysis:
     name: Perform static analysis
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.40.2
+          cache: false
+          environments: fmt
+          activate-environment: true
+      - name: Run formatter and linter
+        run: pixi run fmt
+
+  test:
+    name: Perform tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ['3.13']
-        aiida-version: ['stable']
+        environment: [test-py311, test-py312, test-py313]
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install project manager
-      run: |
-        python -m pip install --upgrade pip
-        pip install hatch
-    - name: Run formatter and linter
-      run: |
-        hatch fmt --check
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.40.2
+          cache: false
+          environments: ${{ matrix.environment }}
+          activate-environment: true
+      - name: Run tests
+        run: pixi run test
 
   docs:
     name: Generate documentation
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      matrix:
-        python-version: ['3.13']
-        aiida-version: ['stable']
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install project manager
-        run: |
-          python -m pip install --upgrade pip
-          pip install hatch
+          pixi-version: v0.40.2
+          cache: false
+          environments: docs
+          activate-environment: true
       - name: Build docs
-        run: |
-          hatch run docs:build
-  
-  # tests:
-    # name: Run tests
+        run: pixi run build-docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,77 +5,43 @@ on:
    types: [released]
 
 jobs:
-#   build:
-#     name: Generate release builds
-#     runs-on: ubuntu-latest
-#     timeout-minutes: 15
-#     strategy:
-#       matrix:
-#         python-version: ['3.13']
-#         aiida-version: ['stable']
-#     steps:
-#     - uses: actions/checkout@v4
-#     - name: Set up Python ${{ matrix.python-version }}
-#       uses: actions/setup-python@v5
-#       with:
-#         python-version: ${{ matrix.python-version }}
-#     - name: Install project manager
-#       run: |
-#         python -m pip install --upgrade pip
-#         pip install hatch
-#     - name: Run builder
-#       run: |
-#         hatch build
-
-#   publish:
-#     name: Upload release to PyPI
-#     needs: build
-#     runs-on: ubuntu-latest
-#     timeout-minutes: 15
-#     strategy:
-#       matrix:
-#         python-version: ['3.13']
-#         aiida-version: ['stable']
-#     environment:
-#       name: pypi
-#       url: https://pypi.org/p/aiida-fans
-#     permissions:
-#       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-#     steps:
-#     - uses: actions/checkout@v4
-#     - name: Set up Python ${{ matrix.python-version }}
-#       uses: actions/setup-python@v5
-#       with:
-#         python-version: ${{ matrix.python-version }}
-#     - name: Publish package distributions to PyPI
-#       uses: pypa/gh-action-pypi-publish@release/v1
-
-  release:
-    name: Create release
+  build:
+    name: Generate release builds
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      matrix:
-        python-version: ['3.13']
-        aiida-version: ['stable']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.40.2
+          cache: false
+          environments: build
+          activate-environment: true
+      - name: Build distributions
+        run: pixi run build-dist
+      - name: Upload release distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  publish:
+    needs: build
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: pypi
       url: https://pypi.org/p/aiida-fans
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install project manager
-      run: |
-        python -m pip install --upgrade pip
-        pip install hatch
-    - name: Run builder
-      run: |
-        hatch build
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ coverage.xml
 cover/
 
 # Environments
+.pixi
 .python-version
 .env
 .venv
@@ -52,5 +53,10 @@ venv.bak/
 docs/build/
 
 # Auto-generated during builds
-/src/hatch/_version.py
 _version.py
+
+# Auto-generated during pull requests
+diff.md
+
+# Lock file
+*.lock

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The design goals of this plugin are primarily to provide as simplistic a user ex
 - [ ] documentation expansion
 - [ ] input validation developed in cooperation with the FANS team
 - [ ] file sharing optimisations
-- [ ] greater database integration via output analysis/extraction 
+- [ ] greater database integration via output analysis/extraction
 
 ## Installation
 The plugin is currently unavailable via PyPI at this stage in development, but it is intended to be published upon an upcoming functional release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,55 +5,94 @@ description = "AiiDA plugin for FANS, an FFT-based homogenization solver."
 urls = {Documentation = "http://aiida-fans.readthedocs.io/en/latest/", Source = "https://github.com/ethan-shanahan/aiida-fans" }
 authors = [{name = "Ethan Shanahan", email = "ethan.shanahan@gmail.com"}]
 readme = "README.md"
-license = "GPL-3.0-only"
-
+license = {file = "LICENSE"}
 classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Operating System :: POSIX :: Linux",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "Development Status :: 1 - Planning",
+    "Development Status :: 3 - Alpha",
     "Framework :: AiiDA"
 ]
 keywords = ["aiida", "plugin", "fans"]
-
-requires-python = ">= 3.11"
+requires-python = ">=3.11"
 dependencies = [
     "aiida-core>=2.3"
 ]
 
-[project.optional-dependencies]
-docs = [
-    "sphinx"
-]
-
 # Entry Points
-[project.entry-points."aiida.data"]
-"fans" = "aiida_fans.data:FANSParameters"
-[project.entry-points."aiida.calculations"]
-"fans" = "aiida_fans.calculations:FANSCalculation"
-[project.entry-points."aiida.parsers"]
-"fans" = "aiida_fans.parsers:FANSParser"
-[project.entry-points."aiida.cmdline.data"]
-"fans" = "aiida_fans.cli:data_cli"
+[project.entry-points]
+"aiida.data" = { "fans" = "aiida_fans.data:FANSParameters" }
+"aiida.calculations" = { "fans" = "aiida_fans.calculations:FANSCalculation" }
+"aiida.parsers" = { "fans" = "aiida_fans.parsers:FANSParser" }
+"aiida.cmdline.data" = { "fans" = "aiida_fans.cli:data_cli" }
 
-# Build
+# Build System
 [build-system]
-build-backend = "hatchling.build"
-requires = ["hatchling", "hatch-vcs"]
-[tool.hatch.version]
-source = "vcs"
-[tool.hatch.build.hooks.vcs]
-version-file = "src/aiida_fans/_version.py"
+requires = ["setuptools>=64", "setuptools_scm>=8"]
+build-backend = "setuptools.build_meta"
 
-# Build - Docs
-[tool.hatch.envs.docs]
-features = ["docs"]
-[tool.hatch.envs.docs.scripts]
-build = "sphinx-build -M html docs/source docs/build"
 
-# Formatting Configuration
+# Tools
+
+## Project Tools: pixi
+[tool.pixi.project]
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+### pixi: default dependencies (in addition to aiida-core)
+[tool.pixi.dependencies]
+fans = "*"
+[tool.pixi.pypi-dependencies]
+# None
+
+### pixi: default tasks
+[tool.pixi.tasks]
+# None
+
+### pixi: features (in addition to fans)
+[tool.pixi.feature.dev]
+pypi-dependencies = {aiida-fans = { path = ".", editable = true }}
+[tool.pixi.feature.prod]
+pypi-dependencies = {aiida-fans = { path = ".", editable = true }}
+[tool.pixi.feature.fmt]
+dependencies = {ruff = "*"}
+tasks = {fmt = "ruff check", dummy = "echo dummy", my-dummy="echo my-dummy"}
+[tool.pixi.feature.build]
+pypi-dependencies = {build = "*"}
+tasks = {build-dist = "python -m build"}
+[tool.pixi.feature.docs]
+dependencies = {sphinx = "*"}
+tasks = {build-docs = "sphinx-build -M html docs/source docs/build"}
+[tool.pixi.feature.test]
+dependencies = {pytest = "*"}
+tasks = {test = "echo dummy test passes"}
+[tool.pixi.feature.py3]
+dependencies = {python = ">=3.11"}
+[tool.pixi.feature.py311]
+dependencies = {python = "3.11.*"}
+[tool.pixi.feature.py312]
+dependencies = {python = "3.12.*"}
+[tool.pixi.feature.py313]
+dependencies = {python = "3.13.*"}
+
+### pixi: environments
+[tool.pixi.environments]
+dev = { features = ["dev", "fmt", "test"], solve-group = "default" }
+fmt = { features = ["fmt", "py3"], no-default-feature = true }
+build = { features = ["build", "py3"], no-default-feature = true }
+docs = { features = ["docs", "py3"], no-default-feature = true }
+test-py311 = { features = ["prod", "test", "py311"], solve-group = "py311" }
+test-py312 = { features = ["prod", "test", "py312"], solve-group = "py312" }
+test-py313 = { features = ["prod", "test", "py313"], solve-group = "py313" }
+
+
+## Build Tools: setuptools_scm
+[tool.setuptools_scm]
+version_file = "src/aiida_fans/_version.py"
+
+## Style Tools: ruff
 [tool.ruff]
 extend-exclude = ["conf.py"]
 line-length = 120
@@ -63,24 +102,25 @@ ignore = [
     "D417"  # Documentation for every function parameter
 ]
 select = [
-  'E',  # pydocstyle
-  'W',  # pydocstyle
-  "D",  # pydocstyle
-  'F',  # pyflakes
-  'I',  # isort
-  'N',  # pep8-naming
-  'PLC',  # pylint-convention
-  'PLE',  # pylint-error
-  'PLR',  # pylint-refactor
-  'PLW',  # pylint-warning
-  'RUF'  # ruff
+    'E',  # pydocstyle
+    'W',  # pydocstyle
+    "D",  # pydocstyle
+    'F',  # pyflakes
+    'I',  # isort
+    'N',  # pep8-naming
+    'PLC',  # pylint-convention
+    'PLE',  # pylint-error
+    'PLR',  # pylint-refactor
+    'PLW',  # pylint-warning
+    'RUF'  # ruff
 ]
-# Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-[tool.ruff.lint.pydocstyle]
-convention = "google"
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"  # Allow unused variables when underscore-prefixed.
+pydocstyle = {convention = "google"}
 
-# Testing Configuration
+## Test Tools: pytest
 [tool.pytest.ini_options]
 [tool.coverage]
 source = ["src/aiida_fans"]
+
+## Docs Tools: sphinx
+# None


### PR DESCRIPTION
* Start tacking the .lock file

* Improved project management systems

* Integrate Pixi into CI

* Improved release workflow

* Ignore Pixi environments

* New lock

* Made prod env install in edit mode

* Temporarily remove test CI

* Dummy tasks

* Remove lock file from source control

* Deactivate pixi action cache

* Use pixi run commands

* Try with active vs prompted env

* Choose active env method

* Automatic lock update

* Use git commands

* Fix formatting

* Specify head ref

* Reintroduce .lock

* # fmt

## linux-64

|Dependency[^1]|Before|After|Change|
|-|-|-|-|
|**python**[^2]|3.13.1|3.12.8|Minor Downgrade|
|**ruff**|py313he87ea70_0|py312h2156523_0|Only build string| |libnsl||2.0.1|Added|
|libxcrypt||4.4.36|Added|
|libmpdec|4.0.0||Removed|
|python_abi[^2]|3.13|3.12|Minor Downgrade|

# dev

## linux-64

|Dependency[^1]|Before|After|Change|
|-|-|-|-|
|**python**[^2]|3.13.1|3.12.8|Minor Downgrade|
|**ruff**|py313he87ea70_0|py312h2156523_0|Only build string| |libnsl||2.0.1|Added|
|libxcrypt||4.4.36|Added|
|libmpdec|4.0.0||Removed|
|python_abi[^2]|3.13|3.12|Minor Downgrade|
|cffi|0.0.0|0.0.0|Other|
|charset_normalizer|0.0.0|0.0.0|Other|
|greenlet|0.0.0|0.0.0|Other|
|markupsafe|0.0.0|0.0.0|Other|
|multidict|0.0.0|0.0.0|Other|
|numpy|0.0.0|0.0.0|Other|
|propcache|0.0.0|0.0.0|Other|
|psycopg2_binary|0.0.0|0.0.0|Other|
|pydantic_core|0.0.0|0.0.0|Other|
|pyyaml|0.0.0|0.0.0|Other|
|pyzmq|0.0.0|0.0.0|Other|
|sqlalchemy|0.0.0|0.0.0|Other|
|wrapt|0.0.0|0.0.0|Other|
|yarl|0.0.0|0.0.0|Other|

[^1]: **Bold** means explicit dependency.
[^2]: Dependency got downgraded.

* Try update with tracked lockfile

* ~ Lockfile Updated ~ Changelog:

* Fix workflow dependencies

* ~ Lockfile Updated ~ Changelog:

* Update lock

* Add pre-commit yaml

* Clean up failed attempts

* Take .lock off vcs

* Add py313 to test CI